### PR TITLE
Fix text not always on center depends on browsers

### DIFF
--- a/src/gauge.js
+++ b/src/gauge.js
@@ -237,7 +237,8 @@
           "font-size": "100%",
           "font-family": "sans-serif",
           "font-weight": "normal",
-          "text-anchor": "middle"
+          "text-anchor": "middle",
+          "alignment-baseline": "middle"
         });
 
         gaugeValuePath = svg("path", {


### PR DESCRIPTION
Hi,

Great little component!

I've fixed a minor issue. Some browsers, like mine, doesn't place completely the text in center of the circle.

```
MacOS High Sierra version 10.13.3 (17D102)
Chrome Version 63.0.3239.132 (Build officiel) (64 bits)
```

Yu.