### PR TITLE
fix: Adding TypeScript React example and correcting types key

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,5 +148,38 @@ const renderGauge = () => (
 );
 ```
 
+## React w/ TypeScript?
+
+```tsx
+import { useEffect, useRef } from 'react'
+import SvgGauge, { GaugeOptions, GaugeInstance } from 'svg-gauge'
+
+const Gauge = ({ value }: Props) => {
+  const gaugeEl = useRef<HTMLDivElement>(null)
+  const gaugeRef = useRef<GaugeInstance | null>(null)
+  useEffect(() => {
+    if (!gaugeRef.current) {
+      if (!gaugeEl.current) return
+      const options: GaugeOptions = { color: value => (value < 30 ? 'green' : 'red') }
+      gaugeRef.current = SvgGauge(gaugeEl.current, options)
+      gaugeRef.current?.setValue(1)
+    }
+    gaugeRef.current?.setValueAnimated(value, 1)
+  }, [value])
+
+  return (
+    <div style={{ width: '500px', height: '500px' }}>
+      <div ref={gaugeEl} />
+    </div>
+  )
+}
+
+interface Props {
+  value: number
+}
+
+export default Gauge
+```
+
 ## And Angular?
 Ha! [It's already there](https://github.com/mattlewis92/angular-gauge)

--- a/package.json
+++ b/package.json
@@ -30,5 +30,5 @@
     "gulp-concat": "~2.6.1",
     "gulp-uglify": "~3.0.1"
   },
-  "typings": "./svg-gauge.d.ts"
+  "types": "./svg-gauge.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -30,5 +30,5 @@
     "gulp-concat": "~2.6.1",
     "gulp-uglify": "~3.0.1"
   },
-  "types": "./svg-gauge.d.ts"
+  "types": "svg-gauge.d.ts"
 }

--- a/svg-gauge.d.ts
+++ b/svg-gauge.d.ts
@@ -1,106 +1,69 @@
-declare var svgGauge: Gauge.GaugeInstance;
-
 declare module 'svg-gauge' {
-  export = svgGauge;
-}
-
-declare namespace Gauge {
-  interface GaugeInstance {
-    /**
-     * Creates a Gauge instance.
-     *
-     * @param {Element} element The DOM into which to render the gauge
-     * @param {GaugeOptions} options The gauge options
-     * @return a gauge instance
-     */
-    (element: Element, options?: GaugeOptions): GaugeInstance;
-    setMaxValue: (max: number) => void;
-    setValue: (val: number) => void;
-    setValueAnimated: (val: number, duration: number) => void;
-    getValue: () => number;
+  export interface GaugeInstance {
+    setMaxValue: (max: number) => void
+    setValue: (val: number) => void
+    setValueAnimated: (val: number, duration: number) => void
+    getValue: () => number
   }
 
-  interface GaugeOptions {
-    /**
-     * The maximum value of the gauge.
+  export interface GaugeOptions {
+    /** The angle in degrees to start the dial
+     * @default 135
+     */
+    dialStartAngle?: number
+    /** The angle in degrees to end the dial. This MUST be less than dialStartAngle
+     * @default 45
+     */
+    dialEndAngle?: number
+    /** The radius of the gauge
+     * @default 40
+     */
+    radius?: number
+    /** The minimum value for the gauge. This can be a negative value
+     * @default 0
+     */
+    min?: number
+    /** The maximum value for the gauge
      * @default 100
      */
-    max?: number;
-
-    /**
-     * @default 0
-     */
-    min?: number;
-
-    /**
-     * The starting value of the gauge.
-     * @default 0
-     */
-    value?: number;
-
-    /**
-     * The gauge's radius.
-     * @default 400
-     */
-    dialRadius?: number;
-
-    /**
+    max?: number
+    /** Getter for the label that will be rendered in the center. */
+    label?: (currentValue: number) => string
+    /** Whether to show the value at the center of the gauge
      * @default true
      */
-    showValue?: boolean;
-
-    /**
-     * The angle to start the dial.
-     * MUST be greater than dialEndAngle.
-     * @default 135deg
-     */
-    dialStartAngle?: number;
-
-    /**
-     * The angle to end the dial.
-     * @default 45deg
-     */
-    dialEndAngle?: number;
-
-    /**
-     * @default 'value'
-     */
-    valueDialClass?: string;
-
-    /**
-     * @default 'value-text'
-     */
-    valueClass?: string;
-
-    /**
-     * @default undefined
-     */
-    valueLabelClass?: string;
-
-    /**
-     * @default 'dial'
-     */
-    dialClass?: string;
-
-    /**
+    showValue?: boolean
+    /** The CSS class of the gauge
      * @default 'gauge'
      */
-    gaugeClass?: string;
-
-    /**
-     * @default null
+    gaugeClass?: string
+    /** The CSS class of the gauge's dial
+     * @default 'dial'
      */
-    color?: (value: number) => string;
-
-    /**
-     * The function on how to render the center label (Should return a value)
-     * @returns the label string
+    dialClass?: string
+    /** The CSS class of the gauge's fill
+     * @default 'value'
      */
-    label?: (value: number) => string;
-
-    /**
-     * @default '0 0 100 100'
+    valueDialClass?: string
+    /** The CSS class of the gauge's text
+     * @default '(value-text)'
      */
-    viewBox?: string;
+    valueClass?: string
+    /** An optional function that can return a color for current value
+     */
+    color?: (currentValue: number) => string
+    /** An optional string that specifies the crop region
+     * @default '(0 0 100 100)'
+     */
+    viewBox?: string
   }
+
+  /**
+   * Creates a Gauge instance.
+   * @param {Element} element The DOM into which to render the gauge
+   * @param {GaugeOptions} options The gauge options
+   */
+  const createInstance: (element: Element, options?: GaugeOptions) => GaugeInstance
+
+  export default createInstance
 }

--- a/typings.json
+++ b/typings.json
@@ -1,5 +1,0 @@
-{
-  "name": "svg-gauge",
-  "main": "svg-gauge.d.ts",
-  "version": false
-}


### PR DESCRIPTION
The key in the package json was not getting picked up by TypeScript, and the types themselves seemed a bit overly complex. 

## Change log
- Added TypeScript React example to README
- Corrected the key in the `package.json` to be `types`, which is what TS is looking for.
- Simplified to types and extended them to export the interfaces so that options can be composed wherever