### PR TITLE
Update gauge on max value change

### DIFF
--- a/src/gauge.js
+++ b/src/gauge.js
@@ -302,6 +302,7 @@
       instance = {
         setMaxValue: function(max) {
           limit = max;
+          updateGauge(value);
         },
         setValue: function(val) {
           value = normalize(val, min, limit);


### PR DESCRIPTION
Before this change, when you call public function updateMaxValue, nothing will happen. 
Adding updateGauge will fix this

Similiar issue like https://github.com/naikus/svg-gauge/issues/59

Real reason for this update is because i want to extend angular fork with option to change maxValue dynamically. In my use case, initially, i have fixed max value which can be lower than value after data has been loaded. That causes the gauge not showing real value, and it is showing maxValue. Updating max value along with value will fix that (and i don't wanna recreate gauge object because of performance)